### PR TITLE
added support for amazon linux 2. rev'd spec tests for amazonlinux 20…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # yum-amazon Cookbook CHANGELOG
 This file is used to list changes made in each version of the yum-amazon cookbook.
 
+## 3.1.0 (2019-05-06)
+
+- Add support for Amazon Linux 2
+
 ## 3.0.0 (2018-02-16)
 
 - Require Chef 12.14+ and remove compat_resource dep

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [![Build Status](https://travis-ci.org/chef-cookbooks/yum-amazon.svg?branch=master)](http://travis-ci.org/chef-cookbooks/yum-amazon) [![Cookbook Version](https://img.shields.io/cookbook/v/yum-amazon.svg)](https://supermarket.chef.io/cookbooks/yum-amazon)
 
-The yum-amazon cookbook takes over management of the default repositoryids that ship with Amazon Linux systems. It allows attribute manipulation of `amzn-main`, `amzn-main-debuginfo`, `amzn-nosrc`, `amzn-updates`, `amzn-updates-debuginfo`, `amzn-preview`, and `amzn-preview-debuginfo`
+The yum-amazon cookbook takes over management of the default repositoryids that ship with Amazon Linux systems. It allows attribute manipulation of `amzn-main`, `amzn-main-debuginfo`, `amzn-nosrc`, `amzn-updates`, `amzn-updates-debuginfo`, `amzn-preview`, and `amzn-preview-debuginfo` on Amazon Linux 1 sytems. It allows attribute manipulation of 'amzn2-core', 'amzn2-core-source', 'amzn2-core-debuginfo' on Amazon Linux 2 systems.
 
 ## Requirements
 
 ### Platforms
 
 - Amazon Linux
+- Amazon Linux 2
 
 ### Chef
 
@@ -147,6 +148,59 @@ default['yum']['amzn-preview-debuginfo']['timeout'] = '10'
 default['yum']['amzn-preview-debuginfo']['report_instanceid'] = true
 ```
 
+```ruby
+default['yum']['amzn2-core']['repositoryid'] = 'amzn2-core'
+default['yum']['amzn2-core']['description'] = 'Amazon Linux 2 core repository'
+default['yum']['amzn2-core']['mirrorlist'] = 'http://amazonlinux.$awsregion.$awsdomain/$releasever/$product/latest/$basearch/mirror.list'
+default['yum']['amzn2-core']['mirror_expire'] = '300'
+default['yum']['amzn2-core']['metadata_expire'] = '300'
+default['yum']['amzn2-core']['priority'] = '10'
+default['yum']['amzn2-core']['failovermethod'] = 'priority'
+default['yum']['amzn2-core']['fastestmirror_enabled'] = false
+default['yum']['amzn2-core']['gpgcheck'] = true
+default['yum']['amzn2-core']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2'
+default['yum']['amzn2-core']['enabled'] = true
+default['yum']['amzn2-core']['managed'] = true
+default['yum']['amzn2-core']['max_retries'] = '5'
+default['yum']['amzn2-core']['timeout'] = '10'
+default['yum']['amzn2-core']['report_instanceid'] = true
+```
+
+```ruby
+default['yum']['amzn2-core-source']['repositoryid'] = 'amzn2-core-source'
+default['yum']['amzn2-core-source']['description'] = 'Amazon Linux 2 core repository - source packages'
+default['yum']['amzn2-core-source']['mirrorlist'] = 'http://amazonlinux.$awsregion.$awsdomain/$releasever/$product/latest/SRPMS/mirror.list'
+default['yum']['amzn2-core-source']['mirror_expire'] = '300'
+default['yum']['amzn2-core-source']['metadata_expire'] = '300'
+default['yum']['amzn2-core-source']['priority'] = '10'
+default['yum']['amzn2-core-source']['failovermethod'] = 'priority'
+default['yum']['amzn2-core-source']['fastestmirror_enabled'] = false
+default['yum']['amzn2-core-source']['gpgcheck'] = true
+default['yum']['amzn2-core-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2'
+default['yum']['amzn2-core-source']['enabled'] = false
+default['yum']['amzn2-core-source']['managed'] = true
+default['yum']['amzn2-core-source']['max_retries'] = '5'
+default['yum']['amzn2-core-source']['timeout'] = '10'
+default['yum']['amzn2-core-source']['report_instanceid'] = true
+```
+
+```ruby
+default['yum']['amzn2-core-debuginfo']['repositoryid'] = 'amzn2-core-debuginfo'
+default['yum']['amzn2-core-debuginfo']['description'] = 'Amazon Linux 2 core repository - debuginfo packages'
+default['yum']['amzn2-core-debuginfo']['mirrorlist'] = 'http://amazonlinux.$awsregion.$awsdomain/$releasever/$product/latest/debuginfo/$basearch/mirror.list'
+default['yum']['amzn2-core-debuginfo']['mirror_expire'] = '300'
+default['yum']['amzn2-core-debuginfo']['metadata_expire'] = '300'
+default['yum']['amzn2-core-debuginfo']['priority'] = '10'
+default['yum']['amzn2-core-debuginfo']['failovermethod'] = 'priority'
+default['yum']['amzn2-core-debuginfo']['fastestmirror_enabled'] = false
+default['yum']['amzn2-core-debuginfo']['gpgcheck'] = true
+default['yum']['amzn2-core-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2'
+default['yum']['amzn2-core-debuginfo']['enabled'] = false
+default['yum']['amzn2-core-debuginfo']['managed'] = true
+default['yum']['amzn2-core-debuginfo']['max_retries'] = '5'
+default['yum']['amzn2-core-debuginfo']['timeout'] = '10'
+default['yum']['amzn2-core-debuginfo']['report_instanceid'] = true
+```
 ## Recipes
 
 - default - Walks through node attributes and feeds a yum_resource

--- a/attributes/amzn2-core-debuginfo.rb
+++ b/attributes/amzn2-core-debuginfo.rb
@@ -1,0 +1,15 @@
+default['yum']['amzn2-core-debuginfo']['repositoryid'] = 'amzn2-core-debuginfo'
+default['yum']['amzn2-core-debuginfo']['description'] = 'Amazon Linux 2 core repository - debuginfo packages'
+default['yum']['amzn2-core-debuginfo']['mirrorlist'] = 'http://amazonlinux.$awsregion.$awsdomain/$releasever/$product/latest/debuginfo/$basearch/mirror.list'
+default['yum']['amzn2-core-debuginfo']['mirror_expire'] = '300'
+default['yum']['amzn2-core-debuginfo']['metadata_expire'] = '300'
+default['yum']['amzn2-core-debuginfo']['priority'] = '10'
+default['yum']['amzn2-core-debuginfo']['failovermethod'] = 'priority'
+default['yum']['amzn2-core-debuginfo']['fastestmirror_enabled'] = false
+default['yum']['amzn2-core-debuginfo']['gpgcheck'] = true
+default['yum']['amzn2-core-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2'
+default['yum']['amzn2-core-debuginfo']['enabled'] = false
+default['yum']['amzn2-core-debuginfo']['managed'] = true
+default['yum']['amzn2-core-debuginfo']['max_retries'] = '5'
+default['yum']['amzn2-core-debuginfo']['timeout'] = '10'
+default['yum']['amzn2-core-debuginfo']['report_instanceid'] = true

--- a/attributes/amzn2-core-source.rb
+++ b/attributes/amzn2-core-source.rb
@@ -1,0 +1,15 @@
+default['yum']['amzn2-core-source']['repositoryid'] = 'amzn2-core-source'
+default['yum']['amzn2-core-source']['description'] = 'Amazon Linux 2 core repository - source packages'
+default['yum']['amzn2-core-source']['mirrorlist'] = 'http://amazonlinux.$awsregion.$awsdomain/$releasever/$product/latest/SRPMS/mirror.list'
+default['yum']['amzn2-core-source']['mirror_expire'] = '300'
+default['yum']['amzn2-core-source']['metadata_expire'] = '300'
+default['yum']['amzn2-core-source']['priority'] = '10'
+default['yum']['amzn2-core-source']['failovermethod'] = 'priority'
+default['yum']['amzn2-core-source']['fastestmirror_enabled'] = false
+default['yum']['amzn2-core-source']['gpgcheck'] = true
+default['yum']['amzn2-core-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2'
+default['yum']['amzn2-core-source']['enabled'] = false
+default['yum']['amzn2-core-source']['managed'] = true
+default['yum']['amzn2-core-source']['max_retries'] = '5'
+default['yum']['amzn2-core-source']['timeout'] = '10'
+default['yum']['amzn2-core-source']['report_instanceid'] = true

--- a/attributes/amzn2-core.rb
+++ b/attributes/amzn2-core.rb
@@ -1,0 +1,15 @@
+default['yum']['amzn2-core']['repositoryid'] = 'amzn2-core'
+default['yum']['amzn2-core']['description'] = 'Amazon Linux 2 core repository'
+default['yum']['amzn2-core']['mirrorlist'] = 'http://amazonlinux.$awsregion.$awsdomain/$releasever/$product/latest/$basearch/mirror.list'
+default['yum']['amzn2-core']['mirror_expire'] = '300'
+default['yum']['amzn2-core']['metadata_expire'] = '300'
+default['yum']['amzn2-core']['priority'] = '10'
+default['yum']['amzn2-core']['failovermethod'] = 'priority'
+default['yum']['amzn2-core']['fastestmirror_enabled'] = false
+default['yum']['amzn2-core']['gpgcheck'] = true
+default['yum']['amzn2-core']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2'
+default['yum']['amzn2-core']['enabled'] = true
+default['yum']['amzn2-core']['managed'] = true
+default['yum']['amzn2-core']['max_retries'] = '5'
+default['yum']['amzn2-core']['timeout'] = '10'
+default['yum']['amzn2-core']['report_instanceid'] = true

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -14,13 +14,18 @@ verifier:
   name: inspec
 
 platforms:
-
-- name: amazonlinux
-  driver:
-    image: amazonlinux:latest
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum -y install lsof which initscripts net-tools sudo wget
+  - name: amazonlinux2
+    driver:
+      image: amazonlinux:latest
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN yum -y install lsof which initscripts net-tools sudo wget
+  - name: amazonlinux
+    driver:
+      image: amazonlinux:1
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN yum -y install lsof which initscripts net-tools sudo wget
 
 suites:
 - name: default

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,6 +12,10 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
+  - name: amazonlinux2
+    driver_config:
+      username: ec2-user
+      password: ec2-user
 
 suites:
 - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and configures the Amazon linux yum repository'
-version '3.0.0'
+version '3.1.0'
 
 supports 'amazon'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,15 +15,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-%w(
-  amzn-main
-  amzn-main-debuginfo
-  amzn-nosrc
-  amzn-preview
-  amzn-preview-debuginfo
-  amzn-updates
-  amzn-updates-debuginfo
-).each do |repo|
+repos = if node['platform_version'] == '2'
+          %w(
+            amzn2-core
+            amzn2-core-source
+            amzn2-core-debuginfo
+          )
+        else
+          %w(
+            amzn-main
+            amzn-main-debuginfo
+            amzn-nosrc
+            amzn-preview
+            amzn-preview-debuginfo
+            amzn-updates
+            amzn-updates-debuginfo
+          )
+        end
+repos.each do |repo|
   yum_repository repo do
     description node['yum'][repo]['description'] unless node['yum'][repo]['description'].nil?
     baseurl node['yum'][repo]['baseurl'] unless node['yum'][repo]['baseurl'].nil?

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'yum-amazon::default' do
-  context 'amazon' do
-    cached(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2016.09').converge(described_recipe) }
+  context 'amazonlinux' do
+    cached(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2018.03').converge(described_recipe) }
 
     it 'creates yum_repository[amzn-main]' do
       expect(chef_run).to create_yum_repository('amzn-main')
@@ -24,6 +24,20 @@ describe 'yum-amazon::default' do
     end
     it 'creates yum_repository[amzn-updates-debuginfo]' do
       expect(chef_run).to create_yum_repository('amzn-updates-debuginfo')
+    end
+  end
+
+  context 'amazonlinux2' do
+    cached(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge(described_recipe) }
+
+    it 'creates yum_repository[amzn2-core]' do
+      expect(chef_run).to create_yum_repository('amzn2-core')
+    end
+    it 'creates yum_repository[amzn2-core-debuginfo]' do
+      expect(chef_run).to create_yum_repository('amzn2-core-debuginfo')
+    end
+    it 'creates yum_repository[amzn2-core-source]' do
+      expect(chef_run).to create_yum_repository('amzn2-core-source')
     end
   end
 


### PR DESCRIPTION
…18.03. updated test kitchen to support amazon linux 2.

Signed-off-by: Heusinkveld, Brian <BHeusinkveld@kapow.com>

### Description

This change adds support for Amazon Linux 2.  This change also updated spec tests to use a more recent version of amazon linux (2018.03).  chefspec and test kitchen updated to include Amazon Linux 2.

### Issues Resolved


### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
