### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This file is used to list changes made in each version of the yum-amazon cookboo
 
 ### ⚠ BREAKING CHANGES
 
-* Amazon Linux 2 support removed. Attribute names changed from amzn2-core* to amazonlinux*.
+* Amazon Linux 2 support removed. Attribute names changed from `amzn2-core*` to `amazonlinux*`.
 * Cookbook no longer provides recipes. Use yum_amazon_repo resource directly.
 
 ### Features

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'yum-amazon'
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'yum-amazon', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -9,6 +9,7 @@ transport:
 
 provisioner:
   name: dokken
+  chef_license: accept
 
 platforms:
   - name: amazonlinux-2023

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- add Policyfile.rb for test cookbook resolution
- remove Berksfile and Berkshelf packaging references
- switch ChefSpec setup to chefspec/policyfile
- fix a changelog wildcard markdownlint violation that blocked the local gate

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list